### PR TITLE
[Feat] 프로젝트 목록 조회 & 프로젝트 삭제 기능 구현

### DIFF
--- a/src/main/java/com/campusform/server/project/application/dto/response/ProjectResponse.java
+++ b/src/main/java/com/campusform/server/project/application/dto/response/ProjectResponse.java
@@ -43,6 +43,8 @@ public class ProjectResponse {
     private List<Long> admins;
     @Schema(description = "프로젝트 생성 시각")
     private LocalDateTime createdAt;
+    @Schema(description = "현재 지원자 수", example = "42")
+    private Long applicantCount;
 
     public static ProjectResponse from(Project project) {
         // lastSyncStatus가 null일 수 있으므로 안전하게 처리
@@ -61,6 +63,28 @@ public class ProjectResponse {
                 project.getStartAt(),
                 project.getEndAt(),
                 project.getAdmins().stream().map(i -> i.getAdminId()).collect(Collectors.toList()),
-                project.getCreatedAt());
+                project.getCreatedAt(),
+                null);
+    }
+
+    public static ProjectResponse from(Project project, long applicantCount) {
+        // lastSyncStatus가 null일 수 있으므로 안전하게 처리
+        String syncStatus = project.getLastSyncStatus() != null
+                ? project.getLastSyncStatus().name()
+                : "NOT_SYNCED";
+
+        return new ProjectResponse(
+                project.getId(),
+                project.getTitle(),
+                project.getOwnerId(),
+                project.getState().name(),
+                project.getSheetUrl(),
+                syncStatus,
+                project.getLastSyncedAt(),
+                project.getStartAt(),
+                project.getEndAt(),
+                project.getAdmins().stream().map(i -> i.getAdminId()).collect(Collectors.toList()),
+                project.getCreatedAt(),
+                applicantCount);
     }
 }

--- a/src/main/java/com/campusform/server/project/application/service/ProjectService.java
+++ b/src/main/java/com/campusform/server/project/application/service/ProjectService.java
@@ -1,6 +1,7 @@
 package com.campusform.server.project.application.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import com.campusform.server.project.application.dto.response.ProjectResponse;
 import com.campusform.server.project.domain.exception.TokenNotFoundException;
 import com.campusform.server.project.domain.model.setting.Project;
 import com.campusform.server.project.domain.repository.ProjectRepository;
+import com.campusform.server.recruiting.infrastructure.persistence.ApplicantJpaRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
+    private final ApplicantJpaRepository applicantJpaRepository;
 
     /**
      * 프로젝트 생성
@@ -76,6 +79,42 @@ public class ProjectService {
         spreadsheetService.syncSheet(project.getId());
 
         return ProjectResponse.from(project);
+    }
+
+    /**
+     * 사용자가 속한 프로젝트 목록 조회 (지원자 수 포함)
+     *
+     * @param userId 사용자 ID (Owner이거나 Admin인 프로젝트만 조회)
+     * @return 프로젝트 목록
+     */
+    @Transactional(readOnly = true)
+    public List<ProjectResponse> getProjectsByUserId(Long userId) {
+        List<Project> projects = projectRepository.findByUserId(userId);
+
+        return projects.stream()
+                .map(project -> {
+                    long applicantCount = applicantJpaRepository.countByProjectId(project.getId());
+                    return ProjectResponse.from(project, applicantCount);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 프로젝트 삭제 (OWNER만 가능)
+     *
+     * @param projectId 프로젝트 ID
+     * @param userId 사용자 ID (OWNER 권한 확인)
+     */
+    @Transactional
+    public void deleteProject(Long projectId, Long userId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다. projectId=" + projectId));
+
+        // OWNER 권한 검증
+        project.validateOwnerAccess(userId);
+
+        // 프로젝트 삭제 (CASCADE로 관련된 ProjectAdmin도 자동 삭제됨)
+        projectRepository.delete(project);
     }
 
     private void validateCreateProjectRequest(CreateProjectRequest request) {

--- a/src/main/java/com/campusform/server/project/domain/repository/ProjectRepository.java
+++ b/src/main/java/com/campusform/server/project/domain/repository/ProjectRepository.java
@@ -1,14 +1,15 @@
 package com.campusform.server.project.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.campusform.server.project.domain.model.setting.Project;
 
 /**
  * 도메인 계층의 infrastructure 인터페이스
- * 
+ *
  * 특정 기술에 의존하지 않고 도메인 관점에서 인터페이스를 서술합니다.
- * 
+ *
  * 따라서 Repository를 사용할 때 본 인터페이스를 사용합니다.
  */
 public interface ProjectRepository {
@@ -18,4 +19,10 @@ public interface ProjectRepository {
     Optional<Project> findById(Long id);
 
     Optional<Project> findBySheetUrl(String sheetUrl);
+
+    List<Project> findAll();
+
+    List<Project> findByUserId(Long userId);
+
+    void delete(Project project);
 }

--- a/src/main/java/com/campusform/server/project/infrastructure/persistence/ProjectJpaRepository.java
+++ b/src/main/java/com/campusform/server/project/infrastructure/persistence/ProjectJpaRepository.java
@@ -1,19 +1,31 @@
 package com.campusform.server.project.infrastructure.persistence;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.campusform.server.project.domain.model.setting.Project;
 
 /**
  * Spring Data JPA를 위한 Project Repository
- * 
+ *
  * 기본 CRUD 메서드와 커스텀 쿼리 메서드를 제공합니다.
  */
 @Repository
 public interface ProjectJpaRepository extends JpaRepository<Project, Long> {
 
     Optional<Project> findBySheetUrl(String sheetUrl);
+
+    /**
+     * 사용자가 Owner이거나 Admin인 프로젝트 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return 사용자가 속한 프로젝트 목록
+     */
+    @Query("SELECT DISTINCT p FROM Project p LEFT JOIN p.admins a WHERE p.ownerId = :userId OR a.adminId = :userId")
+    List<Project> findByUserIdAsOwnerOrAdmin(@Param("userId") Long userId);
 }

--- a/src/main/java/com/campusform/server/project/infrastructure/persistence/ProjectRepositoryImpl.java
+++ b/src/main/java/com/campusform/server/project/infrastructure/persistence/ProjectRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.campusform.server.project.infrastructure.persistence;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * ProjectRepository 구현체
- * 
+ *
  * Spring Data JPA에 작업을 위임합니다.
  * 향후 Querydsl이 필요하면 여기에 추가할 수 있습니다.
  */
@@ -34,5 +35,20 @@ public class ProjectRepositoryImpl implements ProjectRepository {
     @Override
     public Optional<Project> findBySheetUrl(String sheetUrl) {
         return projectJpaRepository.findBySheetUrl(sheetUrl);
+    }
+
+    @Override
+    public List<Project> findAll() {
+        return projectJpaRepository.findAll();
+    }
+
+    @Override
+    public List<Project> findByUserId(Long userId) {
+        return projectJpaRepository.findByUserIdAsOwnerOrAdmin(userId);
+    }
+
+    @Override
+    public void delete(Project project) {
+        projectJpaRepository.delete(project);
     }
 }

--- a/src/main/java/com/campusform/server/project/presentation/ProjectController.java
+++ b/src/main/java/com/campusform/server/project/presentation/ProjectController.java
@@ -1,7 +1,12 @@
 package com.campusform.server.project.presentation;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,6 +40,17 @@ public class ProjectController {
     private final GoogleOAuthTokenService tokenService;
 
     /**
+     * 사용자가 속한 프로젝트 목록 조회
+     */
+    @Operation(summary = "프로젝트 목록 조회", description = "로그인한 사용자가 Owner이거나 Admin인 프로젝트 목록을 조회합니다. 각 프로젝트의 지원자 수가 포함됩니다. (현재는 userId를 직접 받지만, 인증 로직 구현 후에는 토큰에서 추출)")
+    @GetMapping
+    public ResponseEntity<List<ProjectResponse>> getProjects(
+            @Parameter(description = "사용자 ID (테스트용)", required = true) @RequestParam Long userId) {
+        List<ProjectResponse> projects = projectService.getProjectsByUserId(userId);
+        return ResponseEntity.ok(projects);
+    }
+
+    /**
      * 프로젝트 생성
      */
     @Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다. (현재는 ownerId를 직접 받지만, 인증 로직 구현 후에는 토큰에서 추출)")
@@ -44,5 +60,17 @@ public class ProjectController {
             @Parameter(description = "프로젝트 소유자 ID (테스트용)", required = true) @RequestParam Long ownerId) {
         ProjectResponse response = projectService.createProject(ownerId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 프로젝트 삭제 (OWNER만 가능)
+     */
+    @Operation(summary = "프로젝트 삭제", description = "프로젝트를 삭제합니다. OWNER만 삭제 가능하며, 관련된 Admin도 접근할 수 없게 됩니다. (현재는 userId를 직접 받지만, 인증 로직 구현 후에는 토큰에서 추출)")
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<Void> deleteProject(
+            @Parameter(description = "프로젝트 ID", required = true) @PathVariable Long projectId,
+            @Parameter(description = "사용자 ID (테스트용)", required = true) @RequestParam Long userId) {
+        projectService.deleteProject(projectId, userId);
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
- #47 

## Key Changes
- 홈 화면에 첫 진입 시 사용자에게 보이는 화면에서 사용되는 API를 만들었습니다.
    - 프로젝트 목록 조회
    - 프로젝트 삭제 기능
- 위 사항들은 userId, admin_Id, owner_Id 필드를 필터링해서 구현했습니다.

## To Reviewers
- 테스트는 직접 H2 DB에 project를 구현 후 Postman을 이용해 테스트했습니다.
    - http://localhost:8080/api/projects?userId={userId}
    - http://localhost:8080/api/projects/{projectId}?userId={userId}
