### PR TITLE
[Refactor] 쿼리 파라미터로 baseUrl 결정

### DIFF
--- a/src/main/java/com/campusform/server/project/application/service/GoogleOAuthTokenService.java
+++ b/src/main/java/com/campusform/server/project/application/service/GoogleOAuthTokenService.java
@@ -171,17 +171,21 @@ public class GoogleOAuthTokenService {
 
     /**
      * Google Sheets 권한 요청 URL 생성
+     *
+     * @param useLocalhost true면 http://localhost:3000/oauth/google/callback 로 콜백 분기
+     *                     false면 기본값(sheets-redirect-uri) 사용
+     * @return 구글 동의 화면 URL
      */
-    public String buildAuthorizeUrl() {
-        /**
-         * URL 파라미터 준비
-         * 요청 권한(scope): 스트레드 접근
-         * redirect_uri: 권한 승인 후 리다이렉트될 URI
-         */
+    public String buildAuthorizeUrl(boolean useLocalhost) {
+        String redirectUri = useLocalhost ? "http://localhost:3000/oauth/google/callback" : defaultRedirectUri;
+        return buildAuthorizeUrlWithRedirectUri(redirectUri);
+    }
+
+    private String buildAuthorizeUrlWithRedirectUri(String redirectUri) {
         String scope = "https://www.googleapis.com/auth/spreadsheets";
         // URL 인코딩 -> 한글, 특수문자 등 올바르게 처리 보장
         String encodedScope = URLEncoder.encode(scope, StandardCharsets.UTF_8);
-        String encodedRedirectUri = URLEncoder.encode(defaultRedirectUri, StandardCharsets.UTF_8);
+        String encodedRedirectUri = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
 
         // 최종 구글 권한 요청 URL 생성
         return String.format(

--- a/src/main/java/com/campusform/server/project/presentation/GoogleOAuthController.java
+++ b/src/main/java/com/campusform/server/project/presentation/GoogleOAuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campusform.server.identity.application.service.AuthService;
@@ -77,19 +78,16 @@ public class GoogleOAuthController {
      * [호출 시점]
      * - 구글 시트 접근 시 권한이 필요한 경우 (예: 사용자가 구글 시트 연동 버튼 클릭 시)
      * - 사용자를 구글 권한 승인 페이지로 리다이렉트 하기 전 URL 받기 위해 사용
+     *
+     * [useLocalhost] true면 콜백을 http://localhost:3000/oauth/google/callback 로 사용 (로컬
+     * 테스트용).
+     * false 또는 생략이면 app.oauth2.sheets-redirect-uri 사용.
      */
-    @Operation(summary = "Google 권한 요청 URL 생성", description = "Google Sheets API 접근 권한을 얻기 위한 동의 화면 URL을 생성하여 반환합니다.", security = {})
+    @Operation(summary = "Google 권한 요청 URL 생성", description = "Google Sheets API 접근 권한을 얻기 위한 동의 화면 URL을 생성하여 반환합니다. useLocalhost=true 시 로컬(localhost:3000) 콜백으로 분기합니다.", security = {})
     @GetMapping("/authorize-url")
-    public ResponseEntity<Map<String, String>> getAuthorizeUrl() {
-        // 구글 Scope(시트 권한) 요청 URL 생성
-        String authorizeUrl = tokenService.buildAuthorizeUrl();
-
-        /**
-         * 이 링크를 토대로 프론트엔드가 리다이렉트
-         * 
-         * 왜 굳이 백엔드가 리다이렉트 안 시키고 프론트엔드가 리다이렉트 시키는가
-         * 프론트가 직접 흐름을 제어해야 OAuth 완료 후 명확히 context를 관리할 수 있음
-         */
+    public ResponseEntity<Map<String, String>> getAuthorizeUrl(
+            @RequestParam(required = false, defaultValue = "false") boolean useLocalhost) {
+        String authorizeUrl = tokenService.buildAuthorizeUrl(useLocalhost);
         return ResponseEntity.ok(Map.of("authorizeUrl", authorizeUrl));
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
- #65

## Key Changes
1. 쿼리 파라미터로 baseUrl 결정 (authorize-url에 요청 시 true를 주게되면 localhost로 baseUrl 반환)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth 인증 URL 생성 시 로컬호스트 환경 선택 옵션 추가
  * 리다이렉트 URI를 호출 시점에 동적으로 선택할 수 있도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->