### PR TITLE
[Feat] 회원탈퇴기능 추가

### DIFF
--- a/src/main/java/com/campusform/server/global/event/UserDeletedEvent.java
+++ b/src/main/java/com/campusform/server/global/event/UserDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.campusform.server.global.event;
+
+/**
+ * 사용자 회원 탈퇴 이벤트
+ *
+ * Identity Context에서 사용자 계정이 삭제된 직후 발행됩니다.
+ * 다른 바운디드 컨텍스트(프로젝트, 알림, 리크루팅 등)에서 연관 데이터 정리에 사용합니다.
+ */
+public record UserDeletedEvent(Long userId) {
+}

--- a/src/main/java/com/campusform/server/identity/application/service/UserService.java
+++ b/src/main/java/com/campusform/server/identity/application/service/UserService.java
@@ -1,5 +1,6 @@
 package com.campusform.server.identity.application.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +8,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.campusform.server.global.event.UserDeletedEvent;
 import com.campusform.server.global.infrastructure.S3Service;
 import com.campusform.server.identity.domain.model.User;
 import com.campusform.server.identity.domain.repository.UserRepository;
@@ -25,6 +27,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 프로필 이미지 업데이트
@@ -108,5 +111,34 @@ public class UserService {
         log.info("닉네임 수정 완료: userId={}, newNickname={}", userId, newNickname);
 
         return user.getNickname();
+    }
+
+    /**
+     * 회원 탈퇴
+     *
+     * @param userId 사용자 ID
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // // 프로필 이미지가 있다면 S3에서도 삭제
+        // String profileImageUrl = user.getProfileImageUrl();
+        // if (profileImageUrl != null) {
+        //     TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        //         @Override
+        //         public void afterCommit() {
+        //             s3Service.deleteFile(profileImageUrl);
+        //             log.info("S3 프로필 이미지 삭제 완료 (회원탈퇴): {}", profileImageUrl);
+        //         }
+        //     });
+        // }
+
+        userRepository.delete(user);
+        log.info("회원 탈퇴 완료: userId={}", userId);
+
+        // 연관된 데이터 삭제를 위한 이벤트 발행
+        eventPublisher.publishEvent(new UserDeletedEvent(userId));
     }
 }

--- a/src/main/java/com/campusform/server/identity/domain/repository/UserRepository.java
+++ b/src/main/java/com/campusform/server/identity/domain/repository/UserRepository.java
@@ -25,4 +25,6 @@ public interface UserRepository {
     boolean existsById(Long adminId);
 
     List<User> findByIds(List<Long> ids);
+
+    void delete(User user);
 }

--- a/src/main/java/com/campusform/server/identity/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/campusform/server/identity/infrastructure/persistence/UserRepositoryImpl.java
@@ -51,4 +51,9 @@ public class UserRepositoryImpl implements UserRepository {
     public List<User> findByIds(List<Long> ids) {
         return userJpaRepository.findAllById(ids);
     }
+
+    @Override
+    public void delete(User user) {
+        userJpaRepository.delete(user);
+    }
 }

--- a/src/main/java/com/campusform/server/identity/presentation/UserAuthController.java
+++ b/src/main/java/com/campusform/server/identity/presentation/UserAuthController.java
@@ -72,4 +72,13 @@ public class UserAuthController {
         String nickname = userService.updateNickname(userId, request.nickname());
         return new UpdateNicknameResponse(nickname);
     }
+    /**
+     * 회원 탈퇴
+     */
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
+    @DeleteMapping("/me")
+    public void deleteUser(Authentication authentication) {
+        Long userId = authService.extractUserId(authentication);
+        userService.deleteUser(userId);
+    }
 }

--- a/src/main/java/com/campusform/server/notification/application/service/NotificationUserEventListener.java
+++ b/src/main/java/com/campusform/server/notification/application/service/NotificationUserEventListener.java
@@ -1,0 +1,36 @@
+package com.campusform.server.notification.application.service;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campusform.server.global.event.UserDeletedEvent;
+import com.campusform.server.notification.domain.repository.UserNotificationSettingsRepository;
+import com.campusform.server.notification.infrastructure.persistence.NotificationJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationUserEventListener {
+
+    private final UserNotificationSettingsRepository settingsRepository;
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @EventListener
+    @Transactional
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        Long userId = event.userId();
+        log.info("UserDeletedEvent 수신: userId={}", userId);
+
+        settingsRepository.findByUserId(userId).ifPresent(settings -> {
+            log.info("사용자 알림 설정 삭제: userId={}", userId);
+            settingsRepository.delete(settings);
+        });
+
+        log.info("사용자 알림 삭제: receiverId={}", userId);
+        notificationJpaRepository.deleteByReceiverId(userId);
+    }
+}

--- a/src/main/java/com/campusform/server/notification/domain/repository/UserNotificationSettingsRepository.java
+++ b/src/main/java/com/campusform/server/notification/domain/repository/UserNotificationSettingsRepository.java
@@ -14,4 +14,6 @@ public interface UserNotificationSettingsRepository {
     Optional<UserNotificationSettings> findByUserId(Long userId);
 
     boolean existsByUserId(Long userId);
+
+    void delete(UserNotificationSettings settings);
 }

--- a/src/main/java/com/campusform/server/notification/infrastructure/persistence/NotificationJpaRepository.java
+++ b/src/main/java/com/campusform/server/notification/infrastructure/persistence/NotificationJpaRepository.java
@@ -23,4 +23,8 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, L
     @Modifying
     @Query("UPDATE Notification n SET n.readAt = CURRENT_TIMESTAMP WHERE n.receiverId = :receiverId AND n.readAt IS NULL")
     int markAllAsReadByReceiverId(@Param("receiverId") Long receiverId);
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.receiverId = :receiverId")
+    void deleteByReceiverId(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/com/campusform/server/notification/infrastructure/persistence/UserNotificationSettingsRepositoryImpl.java
+++ b/src/main/java/com/campusform/server/notification/infrastructure/persistence/UserNotificationSettingsRepositoryImpl.java
@@ -34,4 +34,9 @@ public class UserNotificationSettingsRepositoryImpl implements UserNotificationS
     public boolean existsByUserId(Long userId) {
         return settingsJpaRepository.existsByUserId(userId);
     }
+
+    @Override
+    public void delete(UserNotificationSettings settings) {
+        settingsJpaRepository.delete(settings);
+    }
 }

--- a/src/main/java/com/campusform/server/project/application/service/ProjectUserEventListener.java
+++ b/src/main/java/com/campusform/server/project/application/service/ProjectUserEventListener.java
@@ -1,0 +1,52 @@
+package com.campusform.server.project.application.service;
+
+import java.util.List;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campusform.server.global.event.UserDeletedEvent;
+import com.campusform.server.project.domain.model.setting.Project;
+import com.campusform.server.project.domain.repository.GoogleOAuthTokenRepository;
+import com.campusform.server.project.domain.repository.ProjectRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProjectUserEventListener {
+
+    private final ProjectRepository projectRepository;
+    private final GoogleOAuthTokenRepository tokenRepository;
+
+    @EventListener
+    @Transactional
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        Long userId = event.userId();
+        log.info("UserDeletedEvent 수신: userId={}", userId);
+
+        // 사용자가 속한 프로젝트 목록 조회 (Owner 또는 Admin)
+        List<Project> projects = projectRepository.findByUserId(userId);
+
+        for (Project project : projects) {
+            if (project.getOwnerId().equals(userId)) {
+                // 사용자가 Owner인 경우 프로젝트 삭제
+                log.info("프로젝트 삭제 (Owner 탈퇴): projectId={}, ownerId={}", project.getId(), userId);
+                projectRepository.delete(project);
+            } else {
+                // 사용자가 Admin인 경우 관리자 목록에서 제거
+                log.info("프로젝트 관리자 제거 (Admin 탈퇴): projectId={}, adminId={}", project.getId(), userId);
+                project.removeAdmin(userId);
+            }
+        }
+
+        // Google OAuth 토큰 삭제
+        tokenRepository.findByOwnerId(userId).ifPresent(token -> {
+            log.info("Google OAuth 토큰 삭제: ownerId={}", userId);
+            tokenRepository.delete(token);
+        });
+    }
+}

--- a/src/main/java/com/campusform/server/recruiting/application/service/RecruitingUserEventListener.java
+++ b/src/main/java/com/campusform/server/recruiting/application/service/RecruitingUserEventListener.java
@@ -1,0 +1,29 @@
+package com.campusform.server.recruiting.application.service;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campusform.server.global.event.UserDeletedEvent;
+import com.campusform.server.recruiting.infrastructure.persistence.CommentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RecruitingUserEventListener {
+
+    private final CommentRepository commentRepository;
+
+    @EventListener
+    @Transactional
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        Long userId = event.userId();
+        log.info("UserDeletedEvent 수신: userId={}", userId);
+
+        log.info("사용자가 작성한 댓글 삭제: authorId={}", userId);
+        commentRepository.deleteByAuthorId(userId);
+    }
+}

--- a/src/main/java/com/campusform/server/recruiting/infrastructure/persistence/CommentRepository.java
+++ b/src/main/java/com/campusform/server/recruiting/infrastructure/persistence/CommentRepository.java
@@ -47,4 +47,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
            "WHERE a.projectId = :projectId " +
            "ORDER BY c.createdAt ASC")
     List<Comment> findAllByProjectIdOrderByCreatedAtAsc(@Param("projectId") Long projectId);
+
+    /**
+     * 특정 작성자의 모든 댓글 삭제
+     */
+    void deleteByAuthorId(Long authorId);
 }


### PR DESCRIPTION
## 관련 이슈번호
- #

## Key Changes
1. 내용
    - user rows를 다 삭제하였습니다.
    - Owner가 회원탈퇴시 프로젝트를 삭제하였고 Admin이 회원탈퇴시 관리자목록에서 삭제하였습니다.
    - 그 후 google oauth 토큰을 삭제, 탈퇴한 회원에게 갔던 알림 삭제, 그 회원이 썼던 댓글도 삭제하였습니다.
  
## To Reviewers

- 프로필 이미지는 삭제하려했으나 테스트하기 어려울 것 같아 주석처리해두었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 자신의 계정을 삭제할 수 있는 기능 추가
  * 계정 삭제 시 관련 데이터(알림 설정, 프로젝트 정보, 댓글) 자동 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->